### PR TITLE
Add POEDITOR_STRINGS_NAMESPACE and POEDITOR_EXTRA_DIRECTIVES

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ Requires an executable `poeditor_config` file in the root of your mobile project
 export POEDITOR_PROJECT_ID=355089
 export POEDITOR_TRANSLATIONS_DIR=./assets/l10n
 export POEDITOR_STRINGS_FILE=./lib/l10n/strings.dart
+export POEDITOR_STRINGS_NAMESPACE=Strings
 export POEDITOR_MAIN_LANG=pl
 export POEDITOR_LANGS=pl
-
+export POEDITOR_EXTRA_DIRECTIVES="export '../my_extensions.dart';"
 ```
 
 You also must provide a POEditor token to the script. You have 3 options:

--- a/bin/poeditor-download
+++ b/bin/poeditor-download
@@ -8,6 +8,8 @@ translationsDir="$POEDITOR_TRANSLATIONS_DIR" # e.g "./assets/l10n"
 stringsFile="$POEDITOR_STRINGS_FILE" # e.g "./lib/l10n/strings.dart"
 mainLang="$POEDITOR_MAIN_LANG" # e.g "pl"
 langs=($POEDITOR_LANGS) # e.g "pl en de"
+stringsNamespace="$POEDITOR_STRINGS_NAMESPACE" # e.g "Strings"
+extraDirectives="${POEDITOR_EXTRA_DIRECTIVES:-}" # e.g "export '../my_extensions.dart';"
 
 mkdir -p "$translationsDir"
 mkdir -p "$(dirname "$stringsFile")"
@@ -43,7 +45,8 @@ done
 # generate Strings class from JSON
 echo "// ignore_for_file: constant_identifier_names" > "$stringsFile"
 echo "" >> "$stringsFile"
-echo "class Strings {" >> "$stringsFile"
+echo "$extraDirectives" >> "$stringsFile"
+echo "class $stringsNamespace {" >> "$stringsFile"
 
 # workaround for https://stackoverflow.com/a/47576101/7009800
 if command -v ghead >& /dev/null


### PR DESCRIPTION
POEDITOR_STRINGS_NAMESPACE is often changed to `S` and `POEDITOR_EXTRA_DIRECTIVES` is useful for exporting other l10n files