### PR TITLE
Specify store type

### DIFF
--- a/bin/generate-keystores
+++ b/bin/generate-keystores
@@ -20,7 +20,8 @@ gen_key() {
     -validity 9125 `# 25 years (25 * 365 = 9125 days)` \
     -alias "${app_name}_$flavor" \
     -dname "O=$owner" \
-    -noprompt
+    -noprompt \
+    -storetype JKS
 }
 
 


### PR DESCRIPTION
In newer java versions the default has been changed and no longer generates JKS by default. This makes sure we always generate JKS regardless of the java version used.