### PR TITLE
Create `pub-publish` action

### DIFF
--- a/.github/actions/pub-release.yaml
+++ b/.github/actions/pub-release.yaml
@@ -1,0 +1,43 @@
+name: Release package to pub.dev
+description: >
+  Release a new package version to pub.dev and link to it from GitHub Releases.
+runs:
+  using: composite
+
+  steps:
+    - name: Download mobile-tools
+      uses: actions/checkout@v3
+      with:
+        repository: leancodepl/mobile-tools
+        path: mobile-tools
+
+    - name: Add mobile-tools to $PATH
+      shell: bash
+      run: |
+        echo "$GITHUB_WORKSPACE/mobile-tools/bin" >> $GITHUB_PATH
+
+    - name: Export release metadata as environment variables
+      shell: bash
+      run: |
+        tag=${{ github.ref_name }}
+        echo "RELEASE_NOTES=$(link_changelog $tag)" >> $GITHUB_ENV
+        echo "IS_PRERELEASE=$(is_prerelease $tag)" >> $GITHUB_ENV
+
+    # If `flutter` command is not available, use `dart pub publish`
+    # If `flutter` command is available, use `flutter pub publish`
+    # See also: https://github.com/dart-lang/setup-dart/issues/68
+    - name: Publish to pub.dev
+      shell: bash
+      run: >
+        if command -v flutter 1>/dev/null 2>&1; then
+          flutter pub publish --force;
+        else
+          dart pub publish --force;
+        fi
+
+    - name: Create release on GitHub
+      uses: softprops/action-gh-release@v1
+      with:
+        name: ${{ github.ref_name }}
+        body: '[See changelog on pub.dev](${{ env.RELEASE_NOTES }})'
+        prerelease: ${{ env.IS_PRERELEASE }}

--- a/.github/workflows/prepare.yaml
+++ b/.github/workflows/prepare.yaml
@@ -3,7 +3,7 @@ name: prepare
 on:
   push:
     branches: [master]
-    tags-ignore: ["v*"]
+    tags-ignore: ['v*']
   pull_request:
     branches: [master]
 

--- a/.github/workflows/prepare.yaml
+++ b/.github/workflows/prepare.yaml
@@ -24,5 +24,5 @@ jobs:
       - name: Run tests with BATS
         run: ./test/bats/bin/bats test/*.bats
 
-      - name: Run shellcheck for changed files
-        run: git diff --name-only -z origin/master bin/ | xargs -0 shellcheck
+      - name: Run shellcheck
+        run: find ./bin -type f -print -exec shellcheck {} +


### PR DESCRIPTION
Idea by @Albert221.

This PR extracts [the common steps](https://github.com/leancodepl/patrol/blob/patrol-v1.0.2/.github/workflows/patrol-publish.yaml#L36-L60) from `publish to pub.dev` Actions into a separate Action.

Repositories to migrate to it:
- https://github.com/leancodepl/patrol
- https://github.com/leancodepl/corelibrary_flutter
- https://github.com/leancodepl/bloc_presentation
- https://github.com/leancodepl/logging_bugfender
- https://github.com/fluttercommunity/flutter_downloader