### PR TITLE
Add `mobile-tools` to `.pubignore`

### DIFF
--- a/.github/actions/pub-release/action.yaml
+++ b/.github/actions/pub-release/action.yaml
@@ -17,10 +17,13 @@ runs:
         repository: leancodepl/mobile-tools
         path: mobile-tools
 
+    - name: Add mobile-tools to .pubignore
+      shell: bash
+      run: echo "/mobile-tools/" >> .pubignore
+
     - name: Add mobile-tools to $PATH
       shell: bash
-      run: |
-        echo "$GITHUB_WORKSPACE/mobile-tools/bin" >> $GITHUB_PATH
+      run: echo "$GITHUB_WORKSPACE/mobile-tools/bin" >> $GITHUB_PATH
 
     - name: Export release metadata as environment variables
       shell: bash

--- a/.github/actions/pub-release/action.yaml
+++ b/.github/actions/pub-release/action.yaml
@@ -17,10 +17,6 @@ runs:
         repository: leancodepl/mobile-tools
         path: mobile-tools
 
-    - name: Add mobile-tools to .pubignore
-      shell: bash
-      run: echo "/mobile-tools/" >> .pubignore
-
     - name: Add mobile-tools to $PATH
       shell: bash
       run: echo "$GITHUB_WORKSPACE/mobile-tools/bin" >> $GITHUB_PATH

--- a/.pubignore
+++ b/.pubignore
@@ -1,0 +1,1 @@
+/mobile-tools/


### PR DESCRIPTION
fixes #29

Initially, I wanted to clone `mobile-tools` outside of `$GITHUB_WORKSPACE` but apparently `actions/checkout@v3` cannot do this ([link](https://github.com/actions/checkout/issues/197)).