### PR TITLE
`pub-release` action: set URL to release notes in output

### DIFF
--- a/.github/actions/pub-release/action.yaml
+++ b/.github/actions/pub-release/action.yaml
@@ -7,6 +7,11 @@ inputs:
     description: Root directory of a Dart package
     default: '.'
 
+outputs:
+  release_notes:
+    description: URL of the release notes on pub.dev
+    value: ${{ steps.create_metadata.outputs.release_notes }}
+
 runs:
   using: composite
 
@@ -28,6 +33,12 @@ runs:
         tag=${{ github.ref_name }}
         echo "RELEASE_NOTES=$(link_changelog $tag)" >> $GITHUB_ENV
         echo "IS_PRERELEASE=$(is_prerelease $tag)" >> $GITHUB_ENV
+
+    - name: Set action output
+      id: create_metadata
+      shell: bash
+      run: |
+        echo "release_notes=${{ env.RELEASE_NOTES }}" >> $GITHUB_OUTPUT
 
     # If `flutter` command is not available, use `dart pub publish`
     # If `flutter` command is available, use `flutter pub publish`


### PR DESCRIPTION
The action already knows the link to the changelog, let's make this knowledge available to all the other actions!

Use case: I want to send a Slack message when new Patrol version is released, and I want to embed the changelog in that message.