### PR TITLE
Add a TODO comment to `pub-release` action

### DIFF
--- a/.github/actions/pub-release/action.yaml
+++ b/.github/actions/pub-release/action.yaml
@@ -3,6 +3,9 @@ description: >
   Release a new package version to pub.dev and link to it from GitHub Releases.
 
 inputs:
+  # TODO: Add "package_name" argument, in case the tag is not in the
+  # "package_name-v1.2.3" format. For example, packages not in monorepo often
+  # have tag in the form of "v1.2.3".
   path:
     description: Root directory of a Dart package
     default: '.'


### PR DESCRIPTION
Probably should've been an issue.