### PR TITLE
Fix `pub-release` Action failing when tag doesn't contain package name

### DIFF
--- a/.github/actions/pub-release/action.yaml
+++ b/.github/actions/pub-release/action.yaml
@@ -3,9 +3,6 @@ description: >
   Release a new package version to pub.dev and link to it from GitHub Releases.
 
 inputs:
-  # TODO: Add "package_name" argument, in case the tag is not in the
-  # "package_name-v1.2.3" format. For example, packages not in monorepo often
-  # have tag in the form of "v1.2.3".
   path:
     description: Root directory of a Dart package
     default: '.'
@@ -53,7 +50,6 @@ runs:
         package_name=${{ steps.extract_package_name.outputs.result }}
         package_version=${{ steps.extract_package_version.outputs.result }}
 
-        tag="${{ github.ref_name }}"
         changelog_url="$(link_changelog "$package_name" "$package_version")"
         prerelease="$(is_prerelease "$package_version")"
         echo "CHANGELOG_URL=$changelog_url" >> $GITHUB_ENV

--- a/.github/actions/pub-release/action.yaml
+++ b/.github/actions/pub-release/action.yaml
@@ -1,21 +1,27 @@
-name: Release package to pub.dev
+name: Release package to pub.dev.
 description: >
   Release a new package version to pub.dev and link to it from GitHub Releases.
 
 inputs:
   path:
-    description: Root directory of a Dart package
+    description: Root directory of a Dart package.
     default: '.'
   dry-run:
     description: If true, no package is published to pub.dev and no GitHub Release is created.
     default: 'false'
 
 outputs:
+  package_name:
+    description: Name of the package.
+    value: ${{ steps.extract_package_name.outputs.result }}
+  package_version:
+    description: Version of the package.
+    value: ${{ steps.extract_package_version.outputs.result }}
   changelog_url:
-    description: URL of the release notes on pub.dev
+    description: URL of the package's release notes on pub.dev.
     value: ${{ steps.create_metadata.outputs.changelog_url }}
   prerelease:
-    description: Whether the published version is a prerelease ("true" or "false")
+    description: Whether the published version is a prerelease ("true" or "false").
     value: ${{ steps.create_metadata.outputs.prerelease }}
 
 runs:

--- a/.github/actions/pub-release/action.yaml
+++ b/.github/actions/pub-release/action.yaml
@@ -42,13 +42,13 @@ runs:
       id: extract_package_name
       uses: mikefarah/yq@master
       with:
-        cmd: cat ${{ inputs.path }}/pubspec.yaml | yq '.name'
+        cmd: cat "${{ inputs.path }}/pubspec.yaml" | yq '.name'
 
     - name: Extract package version from pubspec
       id: extract_package_version
       uses: mikefarah/yq@master
       with:
-        cmd: cat ${{ inputs.path }}/pubspec.yaml | yq '.version'
+        cmd: cat "${{ inputs.path }}/pubspec.yaml" | yq '.version'
 
     - name: Export release metadata as environment variables
       shell: bash

--- a/.github/actions/pub-release/action.yaml
+++ b/.github/actions/pub-release/action.yaml
@@ -35,12 +35,27 @@ runs:
       shell: bash
       run: echo "$GITHUB_WORKSPACE/mobile-tools/bin" >> $GITHUB_PATH
 
+    - name: Extract package name from pubspec
+      id: extract_package_name
+      uses: mikefarah/yq@master
+      with:
+        cmd: cat ${{ inputs.path }}/pubspec.yaml | yq '.name'
+
+    - name: Extract package version from pubspec
+      id: extract_package_version
+      uses: mikefarah/yq@master
+      with:
+        cmd: cat ${{ inputs.path }}/pubspec.yaml | yq '.version'
+
     - name: Export release metadata as environment variables
       shell: bash
       run: |
+        package_name=${{ steps.extract_package_name.outputs.result }}
+        package_version=${{ steps.extract_package_version.outputs.result }}
+
         tag="${{ github.ref_name }}"
-        changelog_url="$(link_changelog $tag)"
-        prerelease="$(is_prerelease $tag)"
+        changelog_url="$(link_changelog "$package_name" "$package_version")"
+        prerelease="$(is_prerelease "$package_version")"
         echo "CHANGELOG_URL=$changelog_url" >> $GITHUB_ENV
         echo "PRERELEASE=$prerelease" >> $GITHUB_ENV
 

--- a/bin/is_prerelease
+++ b/bin/is_prerelease
@@ -16,6 +16,8 @@ set -euo pipefail
 # $ is_prerelease some_single_package v0.7.3
 #
 # $ is_prerelease leancode_contracts leancode_contracts-v2.1.0
+#
+# $ is_prerelease leancode_contracts 2.1.0 # the leading "v" can be ommitted
 
 if [ "$#" = 1 ]; then
     tag="${1:-}"

--- a/bin/link_changelog
+++ b/bin/link_changelog
@@ -18,6 +18,8 @@ set -euo pipefail
 # $ link_changelog leancode_contracts v2.1.0
 #
 # $ link_changelog dispose_scope-v3.0.0-dev.1
+#
+# $ link_changelog dispose_scope 3.0.0-dev.1 # the leading "v" can be ommitted
 
 if [ "$#" = 1 ]; then
     tag="${1:-}"

--- a/test/is_prerelease.bats
+++ b/test/is_prerelease.bats
@@ -11,39 +11,49 @@ setup() {
     assert_failure "error: missing tag"
 }
 
-@test "correctly processes package name and version (1)" {
+@test "correctly processes package name and git tag (1)" {
     run is_prerelease some_package v1
     assert_output false
 }
 
-@test "correctly processes package name and version (2)" {
+@test "correctly processes package name and git tag (2)" {
     run is_prerelease some_package v10
     assert_output false
 }
 
-@test "correctly processes package name and version (3)" {
+@test "correctly processes package name and git tag (3)" {
     run is_prerelease some_package v1.0
     assert_output false
 }
 
-@test "correctly processes package name and version (4)" {
+@test "correctly processes package name and git tag (4)" {
     run is_prerelease some_package v1.0.0+17
     assert_output false
 }
 
-@test "correctly processes package name and version (5)" {
+@test "correctly processes package name and git tag (5)" {
     run is_prerelease some_package v0.1
     assert_output true
 }
 
-@test "correctly processes package name and version (6)" {
+@test "correctly processes package name and git tag (6)" {
     run is_prerelease some_package v0.7.5
     assert_output true
 }
 
-@test "correctly processes package name and git tag (1)" {
+@test "correctly processes package name and git tag (7)" {
     run is_prerelease comms comms-v0.0.5
     assert_output true
+}
+
+@test "correctly processes package name and version (1)" {
+    run is_prerelease some_package 0.7.5
+    assert_output true
+}
+
+@test "correctly processes package name and version (2)" {
+    run is_prerelease some_package 1.0.0
+    assert_output false
 }
 
 @test "correctly processes package name and version with prefix (2)" {

--- a/test/link_changelog.bats
+++ b/test/link_changelog.bats
@@ -16,12 +16,17 @@ setup() {
     assert_failure "error: invalid tag"
 }
 
+@test "correctly processes simple version (1)" {
+    run link_changelog some_package 1.0.0+1
+    assert_output "https://pub.dev/packages/some_package/changelog#1001"
+}
+
 @test "correctly processes simple git tag (1)" {
     run link_changelog some_package-v1
     assert_output "https://pub.dev/packages/some_package/changelog#1"
 }
 
-@test "correctly processes simple  git tag (2)" {
+@test "correctly processes simple git tag (2)" {
     run link_changelog some_package-v1.0.0
     assert_output "https://pub.dev/packages/some_package/changelog#100"
 }


### PR DESCRIPTION
This PR fixes #38.

It also adds 2 new outputs: `package_name` and `package_version`, so that these values can easily be reused (to, for example, send a Slack notification with the new version).