### PR TITLE
Improve `pub-release` action debuggability

### DIFF
--- a/.github/actions/pub-release/action.yaml
+++ b/.github/actions/pub-release/action.yaml
@@ -56,6 +56,9 @@ runs:
         package_name=${{ steps.extract_package_name.outputs.result }}
         package_version=${{ steps.extract_package_version.outputs.result }}
 
+        echo "package name: $package_name"
+        echo "package version: $package_version"
+
         changelog_url="$(link_changelog "$package_name" "$package_version")"
         prerelease="$(is_prerelease "$package_version")"
         echo "CHANGELOG_URL=$changelog_url" >> $GITHUB_ENV


### PR DESCRIPTION
Error that occured in https://github.com/leancodepl/bloc_presentation/pull/12 is hard to understand. Let's print more info so we can debug it better.