### PR TITLE
Add `bs_ios` script

### DIFF
--- a/bin/bs_ios
+++ b/bin/bs_ios
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+echo "all args after parsing: $@"
+
 # bs_ios uploads app binaries for UI testing on BrowserStack.
 #
 # This version of the script works only with the V1 XCUITest API (no XC Test Plans).
@@ -11,8 +13,8 @@ if [[ "$(patrol --version)" != *"v2"* ]]; then
 fi
 
 if [ -z "${CREDS:-}" ]; then
-    echo "Error: missing CREDS env var"
-    exit 1
+	echo "Error: missing CREDS env var"
+	exit 1
 fi
 
 patrol build ios --release "$@"
@@ -59,9 +61,9 @@ echo "Will schedule test execution now"
 
 # https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/builds#execute-a-build
 curl -u "$CREDS" \
-  -X POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/build" \
-  -H "Content-Type: application/json" \
-  --data-binary @- <<EOF
+	-X POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/build" \
+	-H "Content-Type: application/json" \
+	--data-binary @- <<EOF
 {
     "app": "$app_url",
     "testSuite": "$test_url",

--- a/bin/bs_ios
+++ b/bin/bs_ios
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# bs_ios uploads app binaries for UI testing on BrowserStack.
+#
+# This version of the script works only with the V1 endpoint (no Test Plans).
+
+if [[ "$(patrol --version)" != *"v2"* ]]; then
+	echo "Error: patrol_cli v2 is required"
+	exit 1
+fi
+
+if [ -z "${CREDS:-}" ]; then
+    echo "Error: missing CREDS env var"
+    exit 1
+fi
+
+patrol build ios --release
+
+# BrowserStack says it requires .ipa, but actually we can simply zip the .app
+# and rename it.
+
+# TODO: zip the .app and rename it to .ipa
+
+app_upload_response="$(
+	curl -u "$CREDS" \
+		-X POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/app" \
+		-F "file=@$PWD/Runner.ipa"
+)"
+
+app_url="$(echo "$app_upload_response" | jq --raw-output .app_url)"
+echo "Uploaded app, url: $app_url"
+
+echo "Will zip tests now"
+cd build/ios_integ/Build/Products/Release-iphoneos
+rm -f ios_tests.zip
+cp ../Runner_TestPlan_iphoneos*.xctestrun .
+zip -r ios_tests.zip Runner_TestPlan_iphoneos*.xctestrun RunnerUITests-Runner.app
+cd -
+
+test_upload_response="$(
+	curl -u "$CREDS" \
+		-X POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/test-suite" \
+		-F "file=@$PWD/build/ios_integ/Build/Products/Release-iphoneos/ios_tests.zip"
+)"
+
+test_url="$(echo "$test_upload_response" | jq --raw-output .test_suite_url)"
+echo "Uploaded test, url: $test_url"
+
+echo "Will schedule test execution now"
+
+curl -u "$CREDS" \
+  -X POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/xctestrun-build" \
+  -H "Content-Type: application/json" \
+  --data-binary @- <<EOF
+{
+    "app": "$app_url",
+    "testSuite": "$test_url",
+    "project": "patrol_appium_comparison",
+    "devices": ["iPhone 14-16"]
+}
+EOF
+
+
+# "deviceLogs": "true", "dynamicTests": "true", "only-testing": [
+#     "RunnerUITests/RunnerUITests", ]

--- a/bin/bs_ios
+++ b/bin/bs_ios
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # bs_ios uploads app binaries for UI testing on BrowserStack.
 #
-# This version of the script works only with the V1 endpoint (no Test Plans).
+# This version of the script works only with the V1 XCUITest API (no XC Test Plans).
 
 if [[ "$(patrol --version)" != *"v2"* ]]; then
 	echo "Error: patrol_cli v2 is required"
@@ -15,29 +15,37 @@ if [ -z "${CREDS:-}" ]; then
     exit 1
 fi
 
-patrol build ios --release
+patrol build ios --release "$@"
 
 # BrowserStack says it requires .ipa, but actually we can simply zip the .app
 # and rename it.
 
-# TODO: zip the .app and rename it to .ipa
+cd build/ios_integ/Build/Products
 
+rm -rf Payload && mkdir -p Payload
+cp -r Release-iphoneos/Runner.app Payload
+zip -r Runner.ipa Payload
+
+cd -
+
+# https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/apps#upload-an-app
 app_upload_response="$(
 	curl -u "$CREDS" \
 		-X POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/app" \
-		-F "file=@$PWD/Runner.ipa"
+		-F "file=@$PWD/build/ios_integ/Build/Products/Runner.ipa"
 )"
 
 app_url="$(echo "$app_upload_response" | jq --raw-output .app_url)"
 echo "Uploaded app, url: $app_url"
 
-echo "Will zip tests now"
 cd build/ios_integ/Build/Products/Release-iphoneos
+
 rm -f ios_tests.zip
-cp ../Runner_TestPlan_iphoneos*.xctestrun .
-zip -r ios_tests.zip Runner_TestPlan_iphoneos*.xctestrun RunnerUITests-Runner.app
+zip -q -r ios_tests.zip RunnerUITests-Runner.app
+
 cd -
 
+# https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/tests#upload-a-test-suite
 test_upload_response="$(
 	curl -u "$CREDS" \
 		-X POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/test-suite" \
@@ -49,18 +57,22 @@ echo "Uploaded test, url: $test_url"
 
 echo "Will schedule test execution now"
 
+# https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/builds#execute-a-build
 curl -u "$CREDS" \
-  -X POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/xctestrun-build" \
+  -X POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/build" \
   -H "Content-Type: application/json" \
   --data-binary @- <<EOF
 {
     "app": "$app_url",
     "testSuite": "$test_url",
-    "project": "patrol_appium_comparison",
-    "devices": ["iPhone 14-16"]
+    "project": "Patrol example app",
+    "devices": ["iPhone 14-16"],
+    "deviceLogs": "true",
+    "only-testing": [
+        "RunnerUITests/RunnerUITests/exampleTest",
+        "RunnerUITests/RunnerUITests/openAppTest",
+        "RunnerUITests/RunnerUITests/nonExistingTest"
+    ],
+    "dynamicTests": "true"
 }
 EOF
-
-
-# "deviceLogs": "true", "dynamicTests": "true", "only-testing": [
-#     "RunnerUITests/RunnerUITests", ]


### PR DESCRIPTION
This PR adds a shell script that can run tests on BrowserStack's iOS API v1 (i.e no support for XCTestPlans).

Currently the BrowserStack's iOS API v1 doesn't work with Patrol, but it will likely be fixed in the future, thus the PR.