### PR TITLE
Add `bs_ios`, for real this time

### DIFF
--- a/bin/bs_ios
+++ b/bin/bs_ios
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 
-# bs_ios uploads app binaries for UI testing on BrowserStack.
+# DO NOT set -e, otherwise error responses won't be shown to the user.
+
+# bs_ios uploads app binaries for UI testing on BrowserStack. Upon successful
+# completion, it returns build ID of the test run on BrowserStack.
 #
-# This version of the script works only with the V2 endpoint (XC Test Plans).
-# This script assumes that Xcode Test Plan name is TestPlan.xctestplan.
+# This script works only with the V2 endpoint (XC Test Plans). This script
+# assumes that Xcode Test Plan name is TestPlan.xctestplan.
 #
 # It forwards all arguments to "patrol build ios", so you can pass --target,
 # --flavor, --exclude etc. just as you would pass them to "patrol_cli".
@@ -17,7 +20,7 @@ BROWSERSTACK_SKIP_BUILD="${BROWSERSTACK_SKIP_BUILD:-0}"
 BROWSERSTACK_IDLE_TIMEOUT="${BROWSERSTACK_IDLE_TIMEOUT:-900}"
 
 if ! command -v jq >/dev/null 2>&1; then
-  echo "Error: jq not found"
+  1>&2 echo "Error: jq not found"
   exit 1
 fi
 
@@ -44,36 +47,36 @@ while [ $# -gt 0 ]; do
 done
 
 if [ -n "$FLAVOR" ]; then
-	echo "Passed flavor: $FLAVOR"
+	1>&2 echo "Passed flavor: $FLAVOR"
 	FLAVOR_SUFFIXED="-$FLAVOR-"
 	FLAVOR_PREFIXED="$FLAVOR"
 fi
 # Arg parsing end
 
 if [ -z "${BROWSERSTACK_CREDS:-}" ]; then
-	echo "Error: BROWSERSTACK_CREDS not set"
+	1>&2 echo "Error: BROWSERSTACK_CREDS not set"
 	exit 1
 fi
 
 if [ -z "$BROWSERSTACK_PROJECT" ]; then
 	default_project="Unnamed iOS project"
-	echo "BROWSERSTACK_PROJECT not set, using default: $default_project"
+	1>&2 echo "BROWSERSTACK_PROJECT not set, using default: $default_project"
 	BROWSERSTACK_PROJECT="$default_project"
 fi
 
 if [ -z "$BROWSERSTACK_IOS_DEVICES" ]; then
 	default_devices="[\"iPhone 14-16\"]"
-	echo "BROWSERSTACK_IOS_DEVICES not set, using default: $default_devices"
+	1>&2 echo "BROWSERSTACK_IOS_DEVICES not set, using default: $default_devices"
 	BROWSERSTACK_IOS_DEVICES="$default_devices"
 fi
 
 if [ "$BROWSERSTACK_SKIP_BUILD" = 1 ]; then
-	echo "BROWSERSTACK_SKIP_BUILD set to 1, build was skipped"
+	1>&2 echo "BROWSERSTACK_SKIP_BUILD set to 1, build was skipped"
 else
 	patrol build ios --release "${original_args[@]}"
 fi
 
-echo "Will create zip archive of test files"
+1>&2 echo "Will create zip archive of test files"
 
 cd build/ios_integ/Build/Products
 
@@ -93,48 +96,59 @@ cp ../"${FLAVOR_PREFIXED}"_TestPlan_iphoneos*.xctestrun .
 zip -r ios_tests.zip "${FLAVOR_PREFIXED}"_TestPlan_iphoneos*.xctestrun RunnerUITests-Runner.app >/dev/null
 cd - >/dev/null
 
-echo "Created zip archive"
+1>&2 echo "Created zip archive"
 
 app_path="$PWD/build/ios_integ/Build/Products/Runner.ipa"
 if [ ! -f "$app_path" ]; then
-	echo "Error: app under test not found at $app_path"
+	1>&2 echo "Error: app under test not found at $app_path"
 	exit 1
 fi
 
 # https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/apps#upload-an-app
-printf "Will upload app under test from %s\n\n" "$app_path"
+1>&2 printf "Will upload app under test from %s\n\n" "$app_path"
 app_upload_response="$(
-	curl --fail --user "$BROWSERSTACK_CREDS" \
+	curl --fail-with-body --user "$BROWSERSTACK_CREDS" \
 		--request POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/app" \
 		--form "file=@$app_path"
 )"
+if [ $? -ne 0 ]; then
+	1>&2 echo "Error: failed to upload app under test"
+	1>&2 echo "$app_upload_response"
+	exit 1
+fi
 
 app_url="$(echo "$app_upload_response" | jq --raw-output .app_url)"
-printf "\nUploaded app under test, url: %s\n" "$app_url"
+1>&2 printf "\nUploaded app under test, url: %s\n" "$app_url"
 
 test_path="$PWD/build/ios_integ/Build/Products/Release${FLAVOR_SUFFIXED}iphoneos/ios_tests.zip"
 if [ ! -f "$test_path" ]; then
-	echo "Error: zip archive of test suite not found at $test_path"
+	1>&2 echo "Error: zip archive of test suite not found at $test_path"
 	exit 1
 fi
 
 # https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/tests#upload-a-test-suite
-printf "Will upload zip archive of test suite from %s\n\n" "$test_path"
+1>&2 printf "Will upload zip archive of test suite from %s\n\n" "$test_path"
 test_upload_response="$(
-	curl --fail --user "$BROWSERSTACK_CREDS" \
+	curl --fail-with-body --user "$BROWSERSTACK_CREDS" \
 		--request POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/test-suite" \
 		--form "file=@$test_path"
 )"
+if [ $? -ne 0 ]; then
+	1>&2 echo "Error: failed to upload zip archive of test suite"
+	1>&2 echo "$test_upload_response"
+	exit 1
+fi
 
 test_url="$(echo "$test_upload_response" | jq --raw-output .test_suite_url)"
-printf "\nUploaded zip archive of test suite, url: %s\n" "$test_url"
+1>&2 printf "\nUploaded zip archive of test suite, url: %s\n" "$test_url"
 
 # https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/builds#execute-a-build
-printf "Will schedule test execution\n\n"
-curl --fail --user "$BROWSERSTACK_CREDS" \
-	--request POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/xctestrun-build" \
-	--header "Content-Type: application/json" \
-	--data-binary @- <<EOF
+1>&2 printf "Will schedule test execution\n\n"
+run_response="$(
+	curl --fail-with-body --user "$BROWSERSTACK_CREDS" \
+		--request POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/xctestrun-build" \
+		--header "Content-Type: application/json" \
+		--data-binary @- <<EOF
 {
     "app": "$app_url",
     "testSuite": "$test_url",
@@ -145,5 +159,15 @@ curl --fail --user "$BROWSERSTACK_CREDS" \
     "idleTimeout": $BROWSERSTACK_IDLE_TIMEOUT
 }
 EOF
+)"
 
-printf "\n\nScheduled test execution\n"
+if [ $? -ne 0 ]; then
+	1>&2 echo "Error: failed to schedule test execution"
+	1>&2 echo "$run_response"
+	exit 1
+fi
+
+1>&2 printf "\n\nScheduled test execution\n"
+
+build_id="$(echo "$run_response" | jq --raw-output .build_id)"
+echo "$build_id"

--- a/bin/bs_ios
+++ b/bin/bs_ios
@@ -4,103 +4,66 @@ set -euo pipefail
 # bs_ios.sh uploads app binaries for UI testing on BrowserStack.
 #
 # This version of the script works only with the V2 endpoint (XC Test Plans).
-# This scirpt assumes that Xcode Test Plan name is Patrol
+# This script assumes that Xcode Test Plan name is TestPlan.xctestplan.
 #
-# It forwards all arguments to `patrol build ios`, so you can pass --target,
-# --flavor, --exclude etc.
+# It forwards all arguments to "patrol build android", so you can pass --target,
+# --flavor, --exclude etc. just as you would pass them to "patrol_cli".
 #
 # It can also be configured with the following environment variables:
-
 BROWSERSTACK_CREDS="${BROWSERSTACK_CREDS:-}"
+BROWSERSTACK_PROJECT="${BROWSERSTACK_PROJECT:-}"
+BROWSERSTACK_ANDROID_DEVICES="${BROWSERSTACK_ANDROID_DEVICES:-}"
+BROWSERSTACK_SKIP_BUILD="${BROWSERSTACK_SKIP_BUILD:-}"
+BROWSERSTACK_IDLE_TIMEOUT="${BROWSERSTACK_IDLE_TIMEOUT:-}"
 
 # Capture all arguments because they'll be consumed by getopt
 # shellcheck disable=SC2206
 original_args=($@)
 
 # Arg parsing start
-
-# Function to get a value from a YAML config file
-get_config_value() {
-    local key="$1"
-    yq eval ".$key" "bs_config.yaml"
-}
-
-printf "Run configuration:\n"
-project_name=$(get_config_value "project_name")
-printf "\tProject name: %s\n" "$project_name"
-timeout=$(get_config_value "timeout")
-printf "\tTimeout (seconds): %s\n" "$timeout"
-ios_devices=$(get_config_value "ios_devices")
-printf "\tDevices: %s\n" "$ios_devices"
-
-# Define prefix and suffix for flavor
+FLAVOR=""
 FLAVOR_PREFIXED="Runner"
 FLAVOR_SUFFIXED="-"
-
-# Function to fetch flavor from given YAML path in pubspec.yaml
-get_flavor() {
-    local yaml_path=$1
-    yq "$yaml_path // \"\"" <pubspec.yaml
-}
-
-# Try to fetch the flavor from pubspec.yaml
-FLAVOR=$(get_flavor '.patrol.ios.flavor')
-if [ -z "$FLAVOR" ]; then
-    FLAVOR=$(get_flavor '.patrol.flavor')
-fi
 
 TEMP=$(getopt -n "$0" -a -l "flavor:" -- -- "$@")
 eval set -- "$TEMP"
 while [ $# -gt 0 ]; do
-    case "$1" in
-    --flavor)
-        if [ -z "${2:-}" ]; then
-            echo "Error: Argument missing after --flavor option" >&2
-            exit 1
-        fi
-        FLAVOR="$2"
-        shift
-        ;;
-    --) shift ;;
-    esac
-    shift
+	case "$1" in
+	--flavor) FLAVOR="$2"; shift;;
+	--) shift;;
+	esac
+	shift
 done
 
 if [ -n "$FLAVOR" ]; then
-    printf "\tFlavor: %s\n" "$FLAVOR"
+    echo "Passed flavor: $FLAVOR"
     FLAVOR_SUFFIXED="-$FLAVOR-"
     FLAVOR_PREFIXED="$FLAVOR"
-else
-    echo "Error: --flavor argument is required" >&2
-    exit 1
 fi
-
 # Arg parsing end
 
-if [[ "$(patrol --version)" != *"v2"* ]]; then
-    echo "Error: patrol_cli v2 is required" >&2
-    exit 1
-fi
-
 if [ -z "${BROWSERSTACK_CREDS:-}" ]; then
-    echo "Error: missing BROWSERSTACK_CREDS env var" >&2
+    echo "Error: BROWSERSTACK_CREDS not set" >&2
     exit 1
 fi
 
-printf "\n"
-./patrol build ios --release --no-label "${original_args[@]}"
+if [ "$BROWSERSTACK_SKIP_BUILD" = 1 ]; then
+  echo "BROWSERSTACK_SKIP_BUILD set to 1, build was skipped"
+else
+    patrol build ios --release "${original_args[@]}"
+fi
 
-printf "\nZipping test files...\n"
+printf "Will create zip archive of test files\n"
 
 cd build/ios_integ/Build/Products
 
 rm -rf Payload && mkdir -p Payload
-cp -r Release"${FLAVOR_SUFFIXED}"iphoneos/Runner.app Payload
+cp -r "Release${FLAVOR_SUFFIXED}iphoneos/Runner.app" Payload
 zip -r Runner.ipa Payload >/dev/null
 
 cd - >/dev/null
 
-cd build/ios_integ/Build/Products/Release"${FLAVOR_SUFFIXED}"iphoneos
+cd "build/ios_integ/Build/Products/Release${FLAVOR_SUFFIXED}iphoneos"
 rm -rf ios_tests.zip
 
 # BrowserStack fails if DiagnosticCollectionPolicy is present
@@ -133,11 +96,10 @@ test_url="$(
         jq --raw-output .test_suite_url
 )"
 
-echo "Uploaded test, url: $test_url"
-
-printf "\nScheduling test execution...\n"
+echo "Uploaded test instrumentation app, url: $test_url"
 
 # https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/builds#execute-a-build
+printf "Will schedule test execution\n\n"
 curl -u "$BROWSERSTACK_CREDS" \
     -X POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/xctestrun-build" \
     -H "Content-Type: application/json" \
@@ -145,12 +107,12 @@ curl -u "$BROWSERSTACK_CREDS" \
 {
     "app": "$app_url",
     "testSuite": "$test_url",
-    "project": "$project_name",
-    "devices": $ios_devices,
+    "project": "$BROWSERSTACK_PROJECT",
+    "devices": $BROWSERSTACK_IOS_DEVICES,
     "deviceLogs": true,
     "enableResultBundle": true,
-    "idleTimeout": $timeout
+    "idleTimeout": $BROWSERSTACK_IDLE_TIMEOUT
 }
 EOF
 
-printf "\nScheduled test execution"
+printf "\n\nScheduled test execution"

--- a/bin/bs_ios
+++ b/bin/bs_ios
@@ -29,40 +29,43 @@ TEMP=$(getopt -n "$0" -a -l "flavor:" -- -- "$@")
 eval set -- "$TEMP"
 while [ $# -gt 0 ]; do
 	case "$1" in
-	--flavor) FLAVOR="$2"; shift;;
-	--) shift;;
+	--flavor)
+		FLAVOR="$2"
+		shift
+		;;
+	--) shift ;;
 	esac
 	shift
 done
 
 if [ -n "$FLAVOR" ]; then
-    echo "Passed flavor: $FLAVOR"
-    FLAVOR_SUFFIXED="-$FLAVOR-"
-    FLAVOR_PREFIXED="$FLAVOR"
+	echo "Passed flavor: $FLAVOR"
+	FLAVOR_SUFFIXED="-$FLAVOR-"
+	FLAVOR_PREFIXED="$FLAVOR"
 fi
 # Arg parsing end
 
 if [ -z "${BROWSERSTACK_CREDS:-}" ]; then
-    echo "Error: BROWSERSTACK_CREDS not set"
-    exit 1
+	echo "Error: BROWSERSTACK_CREDS not set"
+	exit 1
 fi
 
 if [ -z "$BROWSERSTACK_PROJECT" ]; then
-    default_project="Unnamed iOS project"
-    echo "BROWSERSTACK_PROJECT not set, using default: $default_project"
-    BROWSERSTACK_PROJECT="$default_project"
+	default_project="Unnamed iOS project"
+	echo "BROWSERSTACK_PROJECT not set, using default: $default_project"
+	BROWSERSTACK_PROJECT="$default_project"
 fi
 
 if [ -z "$BROWSERSTACK_IOS_DEVICES" ]; then
-    default_devices="[\"iPhone 14-16\"]"
-    echo "BROWSERSTACK_IOS_DEVICES not set, using default: $default_devices"
-    BROWSERSTACK_IOS_DEVICES="$default_devices"
+	default_devices="[\"iPhone 14-16\"]"
+	echo "BROWSERSTACK_IOS_DEVICES not set, using default: $default_devices"
+	BROWSERSTACK_IOS_DEVICES="$default_devices"
 fi
 
 if [ "$BROWSERSTACK_SKIP_BUILD" = 1 ]; then
-  echo "BROWSERSTACK_SKIP_BUILD set to 1, build was skipped"
+	echo "BROWSERSTACK_SKIP_BUILD set to 1, build was skipped"
 else
-    patrol build ios --release "${original_args[@]}"
+	patrol build ios --release "${original_args[@]}"
 fi
 
 echo "Will create zip archive of test files"
@@ -89,16 +92,16 @@ echo "Created zip archive"
 
 app_path="$PWD/build/ios_integ/Build/Products/Runner.ipa"
 if [ ! -f "$app_path" ]; then
-  echo "Error: app under test not found at $app_path"
-  exit 1
+	echo "Error: app under test not found at $app_path"
+	exit 1
 fi
 
 # https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/apps#upload-an-app
 printf "Will upload app under test from %s\n\n" "$app_path"
 app_upload_response="$(
-    curl -u "$BROWSERSTACK_CREDS" \
-        -X POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/app" \
-        -F "file=@$app_path"
+	curl -u "$BROWSERSTACK_CREDS" \
+		-X POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/app" \
+		-F "file=@$app_path"
 )"
 
 app_url="$(echo "$app_upload_response" | jq --raw-output .app_url)"
@@ -106,17 +109,16 @@ printf "\nUploaded app under test, url: %s\n" "$app_url"
 
 test_path="$PWD/build/ios_integ/Build/Products/Release${FLAVOR_SUFFIXED}iphoneos/ios_tests.zip"
 if [ ! -f "$test_path" ]; then
-  echo "Error: zip archive of test suite not found at $test_path"
-  exit 1
+	echo "Error: zip archive of test suite not found at $test_path"
+	exit 1
 fi
-
 
 # https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/tests#upload-a-test-suite
 printf "Will upload zip archive of test suite from %s\n\n" "$test_path"
 test_upload_response="$(
-    curl -u "$BROWSERSTACK_CREDS" \
-        -X POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/test-suite" \
-        -F "file=@$test_path"
+	curl -u "$BROWSERSTACK_CREDS" \
+		-X POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/test-suite" \
+		-F "file=@$test_path"
 )"
 
 test_url="$(echo "$test_upload_response" | jq --raw-output .test_suite_url)"
@@ -125,9 +127,9 @@ printf "\nUploaded zip archive of test suite, url: %s\n" "$test_url"
 # https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/builds#execute-a-build
 printf "Will schedule test execution\n\n"
 curl -u "$BROWSERSTACK_CREDS" \
-    -X POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/xctestrun-build" \
-    -H "Content-Type: application/json" \
-    --data-binary @- <<EOF
+	-X POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/xctestrun-build" \
+	-H "Content-Type: application/json" \
+	--data-binary @- <<EOF
 {
     "app": "$app_url",
     "testSuite": "$test_url",

--- a/bin/bs_ios
+++ b/bin/bs_ios
@@ -1,20 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# bs_ios.sh uploads app binaries for UI testing on BrowserStack.
+# bs_ios uploads app binaries for UI testing on BrowserStack.
 #
 # This version of the script works only with the V2 endpoint (XC Test Plans).
 # This script assumes that Xcode Test Plan name is TestPlan.xctestplan.
 #
-# It forwards all arguments to "patrol build android", so you can pass --target,
+# It forwards all arguments to "patrol build ios", so you can pass --target,
 # --flavor, --exclude etc. just as you would pass them to "patrol_cli".
 #
 # It can also be configured with the following environment variables:
 BROWSERSTACK_CREDS="${BROWSERSTACK_CREDS:-}"
 BROWSERSTACK_PROJECT="${BROWSERSTACK_PROJECT:-}"
-BROWSERSTACK_ANDROID_DEVICES="${BROWSERSTACK_ANDROID_DEVICES:-}"
-BROWSERSTACK_SKIP_BUILD="${BROWSERSTACK_SKIP_BUILD:-}"
-BROWSERSTACK_IDLE_TIMEOUT="${BROWSERSTACK_IDLE_TIMEOUT:-}"
+BROWSERSTACK_IOS_DEVICES="${BROWSERSTACK_IOS_DEVICES:-}"
+BROWSERSTACK_SKIP_BUILD="${BROWSERSTACK_SKIP_BUILD:-0}"
+BROWSERSTACK_IDLE_TIMEOUT="${BROWSERSTACK_IDLE_TIMEOUT:-900}"
 
 # Capture all arguments because they'll be consumed by getopt
 # shellcheck disable=SC2206
@@ -43,8 +43,20 @@ fi
 # Arg parsing end
 
 if [ -z "${BROWSERSTACK_CREDS:-}" ]; then
-    echo "Error: BROWSERSTACK_CREDS not set" >&2
+    echo "Error: BROWSERSTACK_CREDS not set"
     exit 1
+fi
+
+if [ -z "$BROWSERSTACK_PROJECT" ]; then
+    default_project="Unnamed iOS project"
+    echo "BROWSERSTACK_PROJECT not set, using default: $default_project"
+    BROWSERSTACK_PROJECT="$default_project"
+fi
+
+if [ -z "$BROWSERSTACK_IOS_DEVICES" ]; then
+    default_devices="[\"iPhone 14-16\"]"
+    echo "BROWSERSTACK_IOS_DEVICES not set, using default: $default_devices"
+    BROWSERSTACK_IOS_DEVICES="$default_devices"
 fi
 
 if [ "$BROWSERSTACK_SKIP_BUILD" = 1 ]; then
@@ -53,7 +65,7 @@ else
     patrol build ios --release "${original_args[@]}"
 fi
 
-printf "Will create zip archive of test files\n"
+echo "Will create zip archive of test files"
 
 cd build/ios_integ/Build/Products
 
@@ -67,36 +79,48 @@ cd "build/ios_integ/Build/Products/Release${FLAVOR_SUFFIXED}iphoneos"
 rm -rf ios_tests.zip
 
 # BrowserStack fails if DiagnosticCollectionPolicy is present
-plutil -remove 'TestConfigurations.TestTargets.DiagnosticCollectionPolicy' ../"${FLAVOR_PREFIXED}"_Patrol_iphoneos*.xctestrun
+plutil -remove 'TestConfigurations.TestTargets.DiagnosticCollectionPolicy' ../"${FLAVOR_PREFIXED}"_TestPlan_iphoneos*.xctestrun
 
-cp ../"${FLAVOR_PREFIXED}"_Patrol_iphoneos*.xctestrun .
-zip -r ios_tests.zip "${FLAVOR_PREFIXED}"_Patrol_iphoneos*.xctestrun RunnerUITests-Runner.app >/dev/null
+cp ../"${FLAVOR_PREFIXED}"_TestPlan_iphoneos*.xctestrun .
+zip -r ios_tests.zip "${FLAVOR_PREFIXED}"_TestPlan_iphoneos*.xctestrun RunnerUITests-Runner.app >/dev/null
 cd - >/dev/null
-printf "Completed zipping\n"
 
-printf "\nUploading app...\n"
+echo "Created zip archive"
+
+app_path="$PWD/build/ios_integ/Build/Products/Runner.ipa"
+if [ ! -f "$app_path" ]; then
+  echo "Error: app under test not found at $app_path"
+  exit 1
+fi
 
 # https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/apps#upload-an-app
-app_url="$(
+printf "Will upload app under test from %s\n\n" "$app_path"
+app_upload_response="$(
     curl -u "$BROWSERSTACK_CREDS" \
         -X POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/app" \
-        -F "file=@$PWD/build/ios_integ/Build/Products/Runner.ipa" |
-        jq --raw-output .app_url
+        -F "file=@$app_path"
 )"
 
-echo "Uploaded app, url: $app_url"
+app_url="$(echo "$app_upload_response" | jq --raw-output .app_url)"
+printf "\nUploaded app under test, url: %s\n" "$app_url"
 
-printf "\nUploading test...\n"
+test_path="$PWD/build/ios_integ/Build/Products/Release${FLAVOR_SUFFIXED}iphoneos/ios_tests.zip"
+if [ ! -f "$test_path" ]; then
+  echo "Error: zip archive of test suite not found at $test_path"
+  exit 1
+fi
+
 
 # https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/tests#upload-a-test-suite
-test_url="$(
+printf "Will upload zip archive of test suite from %s\n\n" "$test_path"
+test_upload_response="$(
     curl -u "$BROWSERSTACK_CREDS" \
         -X POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/test-suite" \
-        -F "file=@$PWD/build/ios_integ/Build/Products/Release${FLAVOR_SUFFIXED}iphoneos/ios_tests.zip" |
-        jq --raw-output .test_suite_url
+        -F "file=@$test_path"
 )"
 
-echo "Uploaded test instrumentation app, url: $test_url"
+test_url="$(echo "$test_upload_response" | jq --raw-output .test_suite_url)"
+printf "\nUploaded zip archive of test suite, url: %s\n" "$test_url"
 
 # https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/builds#execute-a-build
 printf "Will schedule test execution\n\n"
@@ -115,4 +139,4 @@ curl -u "$BROWSERSTACK_CREDS" \
 }
 EOF
 
-printf "\n\nScheduled test execution"
+printf "\n\nScheduled test execution\n"

--- a/bin/bs_ios
+++ b/bin/bs_ios
@@ -99,9 +99,9 @@ fi
 # https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/apps#upload-an-app
 printf "Will upload app under test from %s\n\n" "$app_path"
 app_upload_response="$(
-	curl -u "$BROWSERSTACK_CREDS" \
-		-X POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/app" \
-		-F "file=@$app_path"
+	curl --fail --user "$BROWSERSTACK_CREDS" \
+		--request POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/app" \
+		--form "file=@$app_path"
 )"
 
 app_url="$(echo "$app_upload_response" | jq --raw-output .app_url)"
@@ -116,9 +116,9 @@ fi
 # https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/tests#upload-a-test-suite
 printf "Will upload zip archive of test suite from %s\n\n" "$test_path"
 test_upload_response="$(
-	curl -u "$BROWSERSTACK_CREDS" \
-		-X POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/test-suite" \
-		-F "file=@$test_path"
+	curl --fail --user "$BROWSERSTACK_CREDS" \
+		--request POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/test-suite" \
+		--form "file=@$test_path"
 )"
 
 test_url="$(echo "$test_upload_response" | jq --raw-output .test_suite_url)"
@@ -126,9 +126,9 @@ printf "\nUploaded zip archive of test suite, url: %s\n" "$test_url"
 
 # https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/builds#execute-a-build
 printf "Will schedule test execution\n\n"
-curl -u "$BROWSERSTACK_CREDS" \
-	-X POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/xctestrun-build" \
-	-H "Content-Type: application/json" \
+curl --fail --user "$BROWSERSTACK_CREDS" \
+	--request POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/xctestrun-build" \
+	--header "Content-Type: application/json" \
 	--data-binary @- <<EOF
 {
     "app": "$app_url",

--- a/bin/bs_ios
+++ b/bin/bs_ios
@@ -16,6 +16,11 @@ BROWSERSTACK_IOS_DEVICES="${BROWSERSTACK_IOS_DEVICES:-}"
 BROWSERSTACK_SKIP_BUILD="${BROWSERSTACK_SKIP_BUILD:-0}"
 BROWSERSTACK_IDLE_TIMEOUT="${BROWSERSTACK_IDLE_TIMEOUT:-900}"
 
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq not found"
+  exit 1
+fi
+
 # Capture all arguments because they'll be consumed by getopt
 # shellcheck disable=SC2206
 original_args=($@)

--- a/bin/bs_ios
+++ b/bin/bs_ios
@@ -73,39 +73,27 @@ else
 	patrol build ios --release "${original_args[@]}"
 fi
 
-echo "Will create zip archive Runner.ipa"
+echo "Will create zip archive of test files"
+
 cd build/ios_integ/Build/Products
+
 rm -rf Payload && mkdir -p Payload
 cp -r "Release${FLAVOR_SUFFIXED}iphoneos/Runner.app" Payload
 zip -r Runner.ipa Payload >/dev/null
+
 cd - >/dev/null
-echo "Created zip archive Runner.ipa"
 
-cd build/ios_integ/Build/Products
-rm -rf "Release${FLAVOR_SUFFIXED}iphoneos/ios_tests.zip"
+cd "build/ios_integ/Build/Products/Release${FLAVOR_SUFFIXED}iphoneos"
+rm -rf ios_tests.zip
 
-test_run_paths=("$PWD/${FLAVOR_PREFIXED}_TestPlan_iphoneos"*.xctestrun)
-test_run_path="${test_run_paths[0]}"
-test_run_name="$(basename "$test_run_path")"
-echo "Using xctestrun $test_run_name"
-if [ ! -f "$test_run_path" ]; then
-  echo "Error: xctestrun not found at $test_run_path"
-  exit 1
-fi
-
-echo "Will create ios_tests.zip (of RunnerUITests-Runner.app and xctestrun)"
 # BrowserStack fails if DiagnosticCollectionPolicy is present
-plutil -remove 'TestConfigurations.TestTargets.DiagnosticCollectionPolicy' "$test_run_path"
+plutil -remove 'TestConfigurations.TestTargets.DiagnosticCollectionPolicy' ../"${FLAVOR_PREFIXED}"_TestPlan_iphoneos*.xctestrun
 
-# rm "$test_run_name"
-# cp "$test_run_path" .
-zip -r ios_tests.zip "$test_run_name" RunnerUITests-Runner.app >/dev/null
-pushd "Release${FLAVOR_SUFFIXED}iphoneos" >/dev/null
-zip -r ../ios_tests.zip RunnerUITests-Runner.app >/dev/null
-popd
+cp ../"${FLAVOR_PREFIXED}"_TestPlan_iphoneos*.xctestrun .
+zip -r ios_tests.zip "${FLAVOR_PREFIXED}"_TestPlan_iphoneos*.xctestrun RunnerUITests-Runner.app >/dev/null
 cd - >/dev/null
 
-echo "Created ios_tests.zip"
+echo "Created zip archive"
 
 app_path="$PWD/build/ios_integ/Build/Products/Runner.ipa"
 if [ ! -f "$app_path" ]; then
@@ -124,13 +112,12 @@ app_upload_response="$(
 app_url="$(echo "$app_upload_response" | jq --raw-output .app_url)"
 printf "\nUploaded app under test, url: %s\n" "$app_url"
 
-test_path="$PWD/build/ios_integ/Build/Products/ios_tests.zip"
+test_path="$PWD/build/ios_integ/Build/Products/Release${FLAVOR_SUFFIXED}iphoneos/ios_tests.zip"
 if [ ! -f "$test_path" ]; then
 	echo "Error: zip archive of test suite not found at $test_path"
 	exit 1
 fi
 
-set +e
 # https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/tests#upload-a-test-suite
 printf "Will upload zip archive of test suite from %s\n\n" "$test_path"
 test_upload_response="$(
@@ -143,10 +130,8 @@ test_url="$(echo "$test_upload_response" | jq --raw-output .test_suite_url)"
 printf "\nUploaded zip archive of test suite, url: %s\n" "$test_url"
 
 # https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/builds#execute-a-build
-
 printf "Will schedule test execution\n\n"
-run_response="$(
-  curl --user "$BROWSERSTACK_CREDS" \
+curl --fail --user "$BROWSERSTACK_CREDS" \
 	--request POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/xctestrun-build" \
 	--header "Content-Type: application/json" \
 	--data-binary @- <<EOF
@@ -160,10 +145,5 @@ run_response="$(
     "idleTimeout": $BROWSERSTACK_IDLE_TIMEOUT
 }
 EOF
-)"
-
-echo "here"
-
-echo "$run_response" | jq
 
 printf "\n\nScheduled test execution\n"

--- a/bin/bs_ios
+++ b/bin/bs_ios
@@ -73,27 +73,39 @@ else
 	patrol build ios --release "${original_args[@]}"
 fi
 
-echo "Will create zip archive of test files"
-
+echo "Will create zip archive Runner.ipa"
 cd build/ios_integ/Build/Products
-
 rm -rf Payload && mkdir -p Payload
 cp -r "Release${FLAVOR_SUFFIXED}iphoneos/Runner.app" Payload
 zip -r Runner.ipa Payload >/dev/null
-
 cd - >/dev/null
+echo "Created zip archive Runner.ipa"
 
-cd "build/ios_integ/Build/Products/Release${FLAVOR_SUFFIXED}iphoneos"
-rm -rf ios_tests.zip
+cd build/ios_integ/Build/Products
+rm -rf "Release${FLAVOR_SUFFIXED}iphoneos/ios_tests.zip"
 
+test_run_paths=("$PWD/${FLAVOR_PREFIXED}_TestPlan_iphoneos"*.xctestrun)
+test_run_path="${test_run_paths[0]}"
+test_run_name="$(basename "$test_run_path")"
+echo "Using xctestrun $test_run_name"
+if [ ! -f "$test_run_path" ]; then
+  echo "Error: xctestrun not found at $test_run_path"
+  exit 1
+fi
+
+echo "Will create ios_tests.zip (of RunnerUITests-Runner.app and xctestrun)"
 # BrowserStack fails if DiagnosticCollectionPolicy is present
-plutil -remove 'TestConfigurations.TestTargets.DiagnosticCollectionPolicy' ../"${FLAVOR_PREFIXED}"_TestPlan_iphoneos*.xctestrun
+plutil -remove 'TestConfigurations.TestTargets.DiagnosticCollectionPolicy' "$test_run_path"
 
-cp ../"${FLAVOR_PREFIXED}"_TestPlan_iphoneos*.xctestrun .
-zip -r ios_tests.zip "${FLAVOR_PREFIXED}"_TestPlan_iphoneos*.xctestrun RunnerUITests-Runner.app >/dev/null
+# rm "$test_run_name"
+# cp "$test_run_path" .
+zip -r ios_tests.zip "$test_run_name" RunnerUITests-Runner.app >/dev/null
+pushd "Release${FLAVOR_SUFFIXED}iphoneos" >/dev/null
+zip -r ../ios_tests.zip RunnerUITests-Runner.app >/dev/null
+popd
 cd - >/dev/null
 
-echo "Created zip archive"
+echo "Created ios_tests.zip"
 
 app_path="$PWD/build/ios_integ/Build/Products/Runner.ipa"
 if [ ! -f "$app_path" ]; then
@@ -112,12 +124,13 @@ app_upload_response="$(
 app_url="$(echo "$app_upload_response" | jq --raw-output .app_url)"
 printf "\nUploaded app under test, url: %s\n" "$app_url"
 
-test_path="$PWD/build/ios_integ/Build/Products/Release${FLAVOR_SUFFIXED}iphoneos/ios_tests.zip"
+test_path="$PWD/build/ios_integ/Build/Products/ios_tests.zip"
 if [ ! -f "$test_path" ]; then
 	echo "Error: zip archive of test suite not found at $test_path"
 	exit 1
 fi
 
+set +e
 # https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/tests#upload-a-test-suite
 printf "Will upload zip archive of test suite from %s\n\n" "$test_path"
 test_upload_response="$(
@@ -130,8 +143,10 @@ test_url="$(echo "$test_upload_response" | jq --raw-output .test_suite_url)"
 printf "\nUploaded zip archive of test suite, url: %s\n" "$test_url"
 
 # https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/builds#execute-a-build
+
 printf "Will schedule test execution\n\n"
-curl --fail --user "$BROWSERSTACK_CREDS" \
+run_response="$(
+  curl --user "$BROWSERSTACK_CREDS" \
 	--request POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/xctestrun-build" \
 	--header "Content-Type: application/json" \
 	--data-binary @- <<EOF
@@ -145,5 +160,10 @@ curl --fail --user "$BROWSERSTACK_CREDS" \
     "idleTimeout": $BROWSERSTACK_IDLE_TIMEOUT
 }
 EOF
+)"
+
+echo "here"
+
+echo "$run_response" | jq
 
 printf "\n\nScheduled test execution\n"

--- a/bin/bs_ios
+++ b/bin/bs_ios
@@ -26,7 +26,7 @@ fi
 
 # Capture all arguments because they'll be consumed by getopt
 # shellcheck disable=SC2206
-original_args=($@)
+original_args=("$@")
 
 # Arg parsing start
 FLAVOR=""
@@ -78,15 +78,15 @@ fi
 
 1>&2 echo "Will create zip archive of test files"
 
-cd build/ios_integ/Build/Products
+cd build/ios_integ/Build/Products || exit 1
 
 rm -rf Payload && mkdir -p Payload
 cp -r "Release${FLAVOR_SUFFIXED}iphoneos/Runner.app" Payload
 zip -r Runner.ipa Payload >/dev/null
 
-cd - >/dev/null
+cd - >/dev/null || exit 1
 
-cd "build/ios_integ/Build/Products/Release${FLAVOR_SUFFIXED}iphoneos"
+cd "build/ios_integ/Build/Products/Release${FLAVOR_SUFFIXED}iphoneos" || exit 1
 rm -rf ios_tests.zip
 
 # BrowserStack fails if DiagnosticCollectionPolicy is present
@@ -94,7 +94,7 @@ plutil -remove 'TestConfigurations.TestTargets.DiagnosticCollectionPolicy' ../"$
 
 cp ../"${FLAVOR_PREFIXED}"_TestPlan_iphoneos*.xctestrun .
 zip -r ios_tests.zip "${FLAVOR_PREFIXED}"_TestPlan_iphoneos*.xctestrun RunnerUITests-Runner.app >/dev/null
-cd - >/dev/null
+cd - >/dev/null || exit 1
 
 1>&2 echo "Created zip archive"
 
@@ -106,12 +106,11 @@ fi
 
 # https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/apps#upload-an-app
 1>&2 printf "Will upload app under test from %s\n\n" "$app_path"
-app_upload_response="$(
+if ! app_upload_response="$(
 	curl --fail-with-body --user "$BROWSERSTACK_CREDS" \
 		--request POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/app" \
 		--form "file=@$app_path"
-)"
-if [ $? -ne 0 ]; then
+)"; then
 	1>&2 echo "Error: failed to upload app under test"
 	1>&2 echo "$app_upload_response"
 	exit 1
@@ -128,12 +127,11 @@ fi
 
 # https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/tests#upload-a-test-suite
 1>&2 printf "Will upload zip archive of test suite from %s\n\n" "$test_path"
-test_upload_response="$(
+if ! test_upload_response="$(
 	curl --fail-with-body --user "$BROWSERSTACK_CREDS" \
 		--request POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/test-suite" \
 		--form "file=@$test_path"
-)"
-if [ $? -ne 0 ]; then
+)"; then
 	1>&2 echo "Error: failed to upload zip archive of test suite"
 	1>&2 echo "$test_upload_response"
 	exit 1
@@ -144,7 +142,7 @@ test_url="$(echo "$test_upload_response" | jq --raw-output .test_suite_url)"
 
 # https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/builds#execute-a-build
 1>&2 printf "Will schedule test execution\n\n"
-run_response="$(
+if ! run_response="$(
 	curl --fail-with-body --user "$BROWSERSTACK_CREDS" \
 		--request POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/xctestrun-build" \
 		--header "Content-Type: application/json" \
@@ -159,9 +157,7 @@ run_response="$(
     "idleTimeout": $BROWSERSTACK_IDLE_TIMEOUT
 }
 EOF
-)"
-
-if [ $? -ne 0 ]; then
+)"; then
 	1>&2 echo "Error: failed to schedule test execution"
 	1>&2 echo "$run_response"
 	exit 1

--- a/bin/bs_ios
+++ b/bin/bs_ios
@@ -20,12 +20,11 @@ BROWSERSTACK_SKIP_BUILD="${BROWSERSTACK_SKIP_BUILD:-0}"
 BROWSERSTACK_IDLE_TIMEOUT="${BROWSERSTACK_IDLE_TIMEOUT:-900}"
 
 if ! command -v jq >/dev/null 2>&1; then
-  1>&2 echo "Error: jq not found"
-  exit 1
+	echo 1>&2 "Error: jq not found"
+	exit 1
 fi
 
 # Capture all arguments because they'll be consumed by getopt
-# shellcheck disable=SC2206
 original_args=("$@")
 
 # Arg parsing start
@@ -47,36 +46,36 @@ while [ $# -gt 0 ]; do
 done
 
 if [ -n "$FLAVOR" ]; then
-	1>&2 echo "Passed flavor: $FLAVOR"
+	echo 1>&2 "Passed flavor: $FLAVOR"
 	FLAVOR_SUFFIXED="-$FLAVOR-"
 	FLAVOR_PREFIXED="$FLAVOR"
 fi
 # Arg parsing end
 
 if [ -z "${BROWSERSTACK_CREDS:-}" ]; then
-	1>&2 echo "Error: BROWSERSTACK_CREDS not set"
+	echo 1>&2 "Error: BROWSERSTACK_CREDS not set"
 	exit 1
 fi
 
 if [ -z "$BROWSERSTACK_PROJECT" ]; then
 	default_project="Unnamed iOS project"
-	1>&2 echo "BROWSERSTACK_PROJECT not set, using default: $default_project"
+	echo 1>&2 "BROWSERSTACK_PROJECT not set, using default: $default_project"
 	BROWSERSTACK_PROJECT="$default_project"
 fi
 
 if [ -z "$BROWSERSTACK_IOS_DEVICES" ]; then
 	default_devices="[\"iPhone 14-16\"]"
-	1>&2 echo "BROWSERSTACK_IOS_DEVICES not set, using default: $default_devices"
+	echo 1>&2 "BROWSERSTACK_IOS_DEVICES not set, using default: $default_devices"
 	BROWSERSTACK_IOS_DEVICES="$default_devices"
 fi
 
 if [ "$BROWSERSTACK_SKIP_BUILD" = 1 ]; then
-	1>&2 echo "BROWSERSTACK_SKIP_BUILD set to 1, build was skipped"
+	echo 1>&2 "BROWSERSTACK_SKIP_BUILD set to 1, build was skipped"
 else
 	patrol build ios --release "${original_args[@]}"
 fi
 
-1>&2 echo "Will create zip archive of test files"
+echo 1>&2 "Will create zip archive of test files"
 
 cd build/ios_integ/Build/Products || exit 1
 
@@ -96,52 +95,52 @@ cp ../"${FLAVOR_PREFIXED}"_TestPlan_iphoneos*.xctestrun .
 zip -r ios_tests.zip "${FLAVOR_PREFIXED}"_TestPlan_iphoneos*.xctestrun RunnerUITests-Runner.app >/dev/null
 cd - >/dev/null || exit 1
 
-1>&2 echo "Created zip archive"
+echo 1>&2 "Created zip archive"
 
 app_path="$PWD/build/ios_integ/Build/Products/Runner.ipa"
 if [ ! -f "$app_path" ]; then
-	1>&2 echo "Error: app under test not found at $app_path"
+	echo 1>&2 "Error: app under test not found at $app_path"
 	exit 1
 fi
 
 # https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/apps#upload-an-app
-1>&2 printf "Will upload app under test from %s\n\n" "$app_path"
+printf 1>&2 "Will upload app under test from %s\n\n" "$app_path"
 if ! app_upload_response="$(
 	curl --fail-with-body --user "$BROWSERSTACK_CREDS" \
 		--request POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/app" \
 		--form "file=@$app_path"
 )"; then
-	1>&2 echo "Error: failed to upload app under test"
-	1>&2 echo "$app_upload_response"
+	echo 1>&2 "Error: failed to upload app under test"
+	echo 1>&2 "$app_upload_response"
 	exit 1
 fi
 
 app_url="$(echo "$app_upload_response" | jq --raw-output .app_url)"
-1>&2 printf "\nUploaded app under test, url: %s\n" "$app_url"
+printf 1>&2 "\nUploaded app under test, url: %s\n" "$app_url"
 
 test_path="$PWD/build/ios_integ/Build/Products/Release${FLAVOR_SUFFIXED}iphoneos/ios_tests.zip"
 if [ ! -f "$test_path" ]; then
-	1>&2 echo "Error: zip archive of test suite not found at $test_path"
+	echo 1>&2 "Error: zip archive of test suite not found at $test_path"
 	exit 1
 fi
 
 # https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/tests#upload-a-test-suite
-1>&2 printf "Will upload zip archive of test suite from %s\n\n" "$test_path"
+printf 1>&2 "Will upload zip archive of test suite from %s\n\n" "$test_path"
 if ! test_upload_response="$(
 	curl --fail-with-body --user "$BROWSERSTACK_CREDS" \
 		--request POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/test-suite" \
 		--form "file=@$test_path"
 )"; then
-	1>&2 echo "Error: failed to upload zip archive of test suite"
-	1>&2 echo "$test_upload_response"
+	echo 1>&2 "Error: failed to upload zip archive of test suite"
+	echo 1>&2 "$test_upload_response"
 	exit 1
 fi
 
 test_url="$(echo "$test_upload_response" | jq --raw-output .test_suite_url)"
-1>&2 printf "\nUploaded zip archive of test suite, url: %s\n" "$test_url"
+printf 1>&2 "\nUploaded zip archive of test suite, url: %s\n" "$test_url"
 
 # https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/builds#execute-a-build
-1>&2 printf "Will schedule test execution\n\n"
+printf 1>&2 "Will schedule test execution\n\n"
 if ! run_response="$(
 	curl --fail-with-body --user "$BROWSERSTACK_CREDS" \
 		--request POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/xctestrun-build" \
@@ -158,12 +157,12 @@ if ! run_response="$(
 }
 EOF
 )"; then
-	1>&2 echo "Error: failed to schedule test execution"
-	1>&2 echo "$run_response"
+	echo 1>&2 "Error: failed to schedule test execution"
+	echo 1>&2 "$run_response"
 	exit 1
 fi
 
-1>&2 printf "\n\nScheduled test execution\n"
+printf 1>&2 "\n\nScheduled test execution\n"
 
 build_id="$(echo "$run_response" | jq --raw-output .build_id)"
 echo "$build_id"

--- a/bin/bs_ios
+++ b/bin/bs_ios
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# bs_ios.sh uploads app binaries for UI testing on BrowserStack.
+#
+# This version of the script works only with the V2 endpoint (XC Test Plans).
+# This scirpt assumes that Xcode Test Plan name is Patrol
+#
+# It forwards all arguments to `patrol build ios`, so you can pass --target,
+# --flavor, --exclude etc.
+#
+# It can also be configured with the following environment variables:
+
+BROWSERSTACK_CREDS="${BROWSERSTACK_CREDS:-}"
+
+# Capture all arguments because they'll be consumed by getopt
+# shellcheck disable=SC2206
+original_args=($@)
+
+# Arg parsing start
+
+# Function to get a value from a YAML config file
+get_config_value() {
+    local key="$1"
+    yq eval ".$key" "bs_config.yaml"
+}
+
+printf "Run configuration:\n"
+project_name=$(get_config_value "project_name")
+printf "\tProject name: %s\n" "$project_name"
+timeout=$(get_config_value "timeout")
+printf "\tTimeout (seconds): %s\n" "$timeout"
+ios_devices=$(get_config_value "ios_devices")
+printf "\tDevices: %s\n" "$ios_devices"
+
+# Define prefix and suffix for flavor
+FLAVOR_PREFIXED="Runner"
+FLAVOR_SUFFIXED="-"
+
+# Function to fetch flavor from given YAML path in pubspec.yaml
+get_flavor() {
+    local yaml_path=$1
+    yq "$yaml_path // \"\"" <pubspec.yaml
+}
+
+# Try to fetch the flavor from pubspec.yaml
+FLAVOR=$(get_flavor '.patrol.ios.flavor')
+if [ -z "$FLAVOR" ]; then
+    FLAVOR=$(get_flavor '.patrol.flavor')
+fi
+
+TEMP=$(getopt -n "$0" -a -l "flavor:" -- -- "$@")
+eval set -- "$TEMP"
+while [ $# -gt 0 ]; do
+    case "$1" in
+    --flavor)
+        if [ -z "${2:-}" ]; then
+            echo "Error: Argument missing after --flavor option" >&2
+            exit 1
+        fi
+        FLAVOR="$2"
+        shift
+        ;;
+    --) shift ;;
+    esac
+    shift
+done
+
+if [ -n "$FLAVOR" ]; then
+    printf "\tFlavor: %s\n" "$FLAVOR"
+    FLAVOR_SUFFIXED="-$FLAVOR-"
+    FLAVOR_PREFIXED="$FLAVOR"
+else
+    echo "Error: --flavor argument is required" >&2
+    exit 1
+fi
+
+# Arg parsing end
+
+if [[ "$(patrol --version)" != *"v2"* ]]; then
+    echo "Error: patrol_cli v2 is required" >&2
+    exit 1
+fi
+
+if [ -z "${BROWSERSTACK_CREDS:-}" ]; then
+    echo "Error: missing BROWSERSTACK_CREDS env var" >&2
+    exit 1
+fi
+
+printf "\n"
+./patrol build ios --release --no-label "${original_args[@]}"
+
+printf "\nZipping test files...\n"
+
+cd build/ios_integ/Build/Products
+
+rm -rf Payload && mkdir -p Payload
+cp -r Release"${FLAVOR_SUFFIXED}"iphoneos/Runner.app Payload
+zip -r Runner.ipa Payload >/dev/null
+
+cd - >/dev/null
+
+cd build/ios_integ/Build/Products/Release"${FLAVOR_SUFFIXED}"iphoneos
+rm -rf ios_tests.zip
+
+# BrowserStack fails if DiagnosticCollectionPolicy is present
+plutil -remove 'TestConfigurations.TestTargets.DiagnosticCollectionPolicy' ../"${FLAVOR_PREFIXED}"_Patrol_iphoneos*.xctestrun
+
+cp ../"${FLAVOR_PREFIXED}"_Patrol_iphoneos*.xctestrun .
+zip -r ios_tests.zip "${FLAVOR_PREFIXED}"_Patrol_iphoneos*.xctestrun RunnerUITests-Runner.app >/dev/null
+cd - >/dev/null
+printf "Completed zipping\n"
+
+printf "\nUploading app...\n"
+
+# https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/apps#upload-an-app
+app_url="$(
+    curl -u "$BROWSERSTACK_CREDS" \
+        -X POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/app" \
+        -F "file=@$PWD/build/ios_integ/Build/Products/Runner.ipa" |
+        jq --raw-output .app_url
+)"
+
+echo "Uploaded app, url: $app_url"
+
+printf "\nUploading test...\n"
+
+# https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/tests#upload-a-test-suite
+test_url="$(
+    curl -u "$BROWSERSTACK_CREDS" \
+        -X POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/test-suite" \
+        -F "file=@$PWD/build/ios_integ/Build/Products/Release${FLAVOR_SUFFIXED}iphoneos/ios_tests.zip" |
+        jq --raw-output .test_suite_url
+)"
+
+echo "Uploaded test, url: $test_url"
+
+printf "\nScheduling test execution...\n"
+
+# https://www.browserstack.com/docs/app-automate/api-reference/xcuitest/builds#execute-a-build
+curl -u "$BROWSERSTACK_CREDS" \
+    -X POST "https://api-cloud.browserstack.com/app-automate/xcuitest/v2/xctestrun-build" \
+    -H "Content-Type: application/json" \
+    --data-binary @- <<EOF
+{
+    "app": "$app_url",
+    "testSuite": "$test_url",
+    "project": "$project_name",
+    "devices": $ios_devices,
+    "deviceLogs": true,
+    "enableResultBundle": true,
+    "idleTimeout": $timeout
+}
+EOF
+
+printf "\nScheduled test execution"


### PR DESCRIPTION
Supersedes #45

Changes:
- required XC Test Plan name is `TestPlan.xctestplan`
- possibility to skip `patrol build ios` if env var `BROWSERSTACK_SKIP_BUILD` is set to `1`