### PR TITLE
Update GitHub Actions dependencies from Node.js 16 to Node.js 20

### DIFF
--- a/.github/actions/pub-release/action.yaml
+++ b/.github/actions/pub-release/action.yaml
@@ -29,7 +29,7 @@ runs:
 
   steps:
     - name: Download mobile-tools
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: leancodepl/mobile-tools
         path: mobile-tools
@@ -91,7 +91,7 @@ runs:
         fi
 
     - name: Create release on GitHub
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       if: inputs.dry-run == 'false'
       with:
         name: ${{ github.ref_name }}

--- a/.github/workflows/prepare.yaml
+++ b/.github/workflows/prepare.yaml
@@ -19,7 +19,7 @@ jobs:
           submodules: recursive
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           check-latest: true
 


### PR DESCRIPTION
[GitHub Actions: Transitioning from Node 16 to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)

No behavior changes expected:
- [softprops/action-gh-release releases](https://github.com/softprops/action-gh-release/releases)
- [actions/checkout releases](https://github.com/actions/checkout/releases)

cc @shilangyu