### PR TITLE
Make bs_ios work on macos 26 

### DIFF
--- a/bin/bs_ios
+++ b/bin/bs_ios
@@ -89,7 +89,7 @@ cd "build/ios_integ/Build/Products/Release${FLAVOR_SUFFIXED}iphoneos" || exit 1
 rm -rf ios_tests.zip
 
 # BrowserStack fails if DiagnosticCollectionPolicy is present
-plutil -remove 'TestConfigurations.TestTargets.DiagnosticCollectionPolicy' ../"${FLAVOR_PREFIXED}"_TestPlan_iphoneos*.xctestrun
+plutil -remove 'TestConfigurations.0.TestTargets.0.DiagnosticCollectionPolicy' ../"${FLAVOR_PREFIXED}"_TestPlan_iphoneos*.xctestrun
 
 cp ../"${FLAVOR_PREFIXED}"_TestPlan_iphoneos*.xctestrun .
 zip -r ios_tests.zip "${FLAVOR_PREFIXED}"_TestPlan_iphoneos*.xctestrun RunnerUITests-Runner.app >/dev/null


### PR DESCRIPTION
It shouldn't break older macos versions.

The keypath in plutil command on macos 26 require array index though both those arrays have only one item and on older macos it works without those zeroes. Now it works on both 26 and older.