### PR TITLE
fix(pana-score): namespace commit status per package

### DIFF
--- a/.github/actions/pana-score/README.md
+++ b/.github/actions/pana-score/README.md
@@ -32,7 +32,7 @@ publishing its status and summary.
 
 ## Outputs
 
-- `score`: e.g. `package-name: 98/100`.
+- `score`: e.g. `98/100`.
 - `state`: one of `success`, `failure`, `error`.
 - `package-name`: resolved from the package's `pubspec.yaml` (or its directory
   name), used to namespace the commit status context.

--- a/.github/actions/pana-score/README.md
+++ b/.github/actions/pana-score/README.md
@@ -6,7 +6,9 @@ Self-contained composite action that:
 - installs and runs `pana --json`,
 - exposes `score` and `state` outputs,
 - writes Markdown details to `$GITHUB_STEP_SUMMARY`,
-- reports a `pana` commit status on the head SHA (fork-safe for pull requests),
+- reports a `pana (<package-name>)` commit status on the head SHA (fork-safe for
+  pull requests), so scoring several packages in one workflow gives each its own
+  status entry instead of overwriting a shared one,
 - fails when no valid score is present.
 
 ## Usage
@@ -32,6 +34,8 @@ publishing its status and summary.
 
 - `score`: e.g. `package-name: 98/100`.
 - `state`: one of `success`, `failure`, `error`.
+- `package-name`: resolved from the package's `pubspec.yaml` (or its directory
+  name), used to namespace the commit status context.
 
 ## Required workflow permissions
 

--- a/.github/actions/pana-score/action.yaml
+++ b/.github/actions/pana-score/action.yaml
@@ -18,6 +18,9 @@ outputs:
   state:
     description: pana result state (`success`, `failure`, or `error`).
     value: ${{ steps.score.outputs.state }}
+  package-name:
+    description: Name resolved from the package's `pubspec.yaml` (or its directory name).
+    value: ${{ steps.score.outputs.package-name }}
 
 runs:
   using: composite
@@ -71,6 +74,7 @@ runs:
         echo "score=$score" >> "$GITHUB_OUTPUT"
         echo "state=$state" >> "$GITHUB_OUTPUT"
         echo "valid_score=$valid_score" >> "$GITHUB_OUTPUT"
+        echo "package-name=$package_name" >> "$GITHUB_OUTPUT"
 
         {
           echo "## pana score: $score"
@@ -103,12 +107,18 @@ runs:
         SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         STATE: ${{ steps.score.outputs.state || 'error' }}
         SCORE: ${{ steps.score.outputs.score || 'pana produced no score' }}
+        PACKAGE_NAME: ${{ steps.score.outputs.package-name }}
         TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       run: |
+        context="pana"
+        if [ -n "$PACKAGE_NAME" ]; then
+          context="pana ($PACKAGE_NAME)"
+        fi
+
         gh api "repos/$GITHUB_REPOSITORY/statuses/$SHA" \
           --silent \
           -f state="$STATE" \
-          -f context='pana' \
+          -f context="$context" \
           -f description="$SCORE" \
           -f target_url="$TARGET_URL"
 

--- a/.github/actions/pana-score/action.yaml
+++ b/.github/actions/pana-score/action.yaml
@@ -13,7 +13,7 @@ inputs:
 
 outputs:
   score:
-    description: "Package score text in the form `package-name: granted/max`."
+    description: "Package score text in the form `granted/max`."
     value: ${{ steps.score.outputs.score }}
   state:
     description: pana result state (`success`, `failure`, or `error`).
@@ -55,13 +55,13 @@ runs:
         max="$(jq -r '.scores.maxPoints // empty' "$RUNNER_TEMP/pana.json" 2>/dev/null || true)"
 
         valid_score=true
-        score="${package_name}: ${granted}/${max}"
+        score="${granted}/${max}"
         state=failure
 
         case "$granted$max" in
           '' | *[!0-9]*)
             valid_score=false
-            score="${package_name}: pana produced no score"
+            score="pana produced no score"
             state=error
             echo "::error title=pana score::no score in pana's JSON report"
             ;;
@@ -77,7 +77,7 @@ runs:
         echo "package-name=$package_name" >> "$GITHUB_OUTPUT"
 
         {
-          echo "## pana score: $score"
+          echo "## pana score for $package_name: $score"
           echo
           jq -r '(.report.sections // [])[]
             | "- \(if .grantedPoints == .maxPoints then ":white_check_mark:" else ":x:" end) \(.title): \(.grantedPoints)/\(.maxPoints)"' \


### PR DESCRIPTION
Scoring multiple packages in one PR previously reported them all under the same "pana" status context, so each run overwrote the last. The status context now includes the resolved package name, and it's exposed as a new package-name output.