### PR TITLE
fix(pana-score): avoid Dart SDK install collision

### DIFF
--- a/.github/actions/pana-score/action.yaml
+++ b/.github/actions/pana-score/action.yaml
@@ -29,23 +29,34 @@ runs:
     # dart-lang/setup-dart downloads to a fixed filename under $RUNNER_TEMP and
     # doesn't clean it up, so calling this action more than once in the same
     # job (e.g. scoring several packages) makes the second install collide
-    # with the first's leftover zip. Skip re-running it once Dart is ready,
-    # and clear any stale download before we do run it.
+    # with the first's leftover zip. Only (re)install when what's on PATH
+    # isn't already the latest stable SDK, and clear any stale download
+    # first so a reinstall can't collide with itself either.
+    - name: Check for an up-to-date stable Dart SDK
+      id: dart-check
+      shell: bash
+      run: |
+        latest="$(curl -fsSL https://storage.googleapis.com/dart-archive/channels/stable/release/latest/VERSION | jq -r '.version' || true)"
+        version_line="$(dart --version 2>&1 || true)"
+        current="$(awk '{print $4}' <<< "$version_line")"
+        channel="$(awk '{print $5}' <<< "$version_line" | tr -d '()')"
+
+        up_to_date=false
+        if [ -n "$latest" ] && [ "$channel" = "stable" ] && [ "$current" = "$latest" ]; then
+          up_to_date=true
+        fi
+        echo "up-to-date=$up_to_date" >> "$GITHUB_OUTPUT"
+
     - name: Clear stale Dart SDK download
-      if: env.PANA_DART_SDK_READY != 'true'
+      if: steps.dart-check.outputs.up-to-date != 'true'
       shell: bash
       run: rm -f "$RUNNER_TEMP"/dartsdk-*.zip
 
     - name: Set up stable Dart for pana
-      if: env.PANA_DART_SDK_READY != 'true'
+      if: steps.dart-check.outputs.up-to-date != 'true'
       uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
       with:
         sdk: stable # the score has to be the one pub.dev will give
-
-    - name: Mark Dart SDK ready for reuse
-      if: env.PANA_DART_SDK_READY != 'true'
-      shell: bash
-      run: echo "PANA_DART_SDK_READY=true" >> "$GITHUB_ENV"
 
     - name: Install pana
       shell: bash

--- a/.github/actions/pana-score/action.yaml
+++ b/.github/actions/pana-score/action.yaml
@@ -26,10 +26,26 @@ runs:
   using: composite
 
   steps:
+    # dart-lang/setup-dart downloads to a fixed filename under $RUNNER_TEMP and
+    # doesn't clean it up, so calling this action more than once in the same
+    # job (e.g. scoring several packages) makes the second install collide
+    # with the first's leftover zip. Skip re-running it once Dart is ready,
+    # and clear any stale download before we do run it.
+    - name: Clear stale Dart SDK download
+      if: env.PANA_DART_SDK_READY != 'true'
+      shell: bash
+      run: rm -f "$RUNNER_TEMP"/dartsdk-*.zip
+
     - name: Set up stable Dart for pana
+      if: env.PANA_DART_SDK_READY != 'true'
       uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
       with:
         sdk: stable # the score has to be the one pub.dev will give
+
+    - name: Mark Dart SDK ready for reuse
+      if: env.PANA_DART_SDK_READY != 'true'
+      shell: bash
+      run: echo "PANA_DART_SDK_READY=true" >> "$GITHUB_ENV"
 
     - name: Install pana
       shell: bash

--- a/.github/actions/pana-score/action.yaml
+++ b/.github/actions/pana-score/action.yaml
@@ -26,12 +26,7 @@ runs:
   using: composite
 
   steps:
-    # dart-lang/setup-dart downloads to a fixed filename under $RUNNER_TEMP and
-    # doesn't clean it up, so calling this action more than once in the same
-    # job (e.g. scoring several packages) makes the second install collide
-    # with the first's leftover zip. Only (re)install when what's on PATH
-    # isn't already the latest stable SDK, and clear any stale download
-    # first so a reinstall can't collide with itself either.
+    # Avoids re-downloading (and colliding with leftover files) when Dart is already up to date.
     - name: Check for an up-to-date stable Dart SDK
       id: dart-check
       shell: bash


### PR DESCRIPTION
## Summary

- `dart-lang/setup-dart` downloads to a fixed filename under `$RUNNER_TEMP` without cleaning it up, so calling the `pana-score` action more than once in the same job (e.g. scoring several packages, which the README already documents as a supported use case) makes the second install collide with the first's leftover zip and fail with `Destination file path ... already exists`.
- Added a check that queries dart-archive's `latest/VERSION` and compares it against `dart --version` already on `PATH`; `dart-lang/setup-dart` is now only run when the installed SDK isn't already the latest stable release.
- Before a (re)install, any stale `dartsdk-*.zip` in `$RUNNER_TEMP` is removed so the download can't collide with itself either.

## Test plan

- [ ] Trigger a workflow that calls `pana-score` more than once in the same job and confirm the second call skips the Dart install instead of failing.
- [ ] Confirm a single call still installs Dart and scores the package correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nj7viBuUNGPe4rmqoC15MQ)_