### PR TITLE
fix(pana-score): set up Flutter and webp tools pana needs

### DIFF
--- a/.github/actions/pana-score/README.md
+++ b/.github/actions/pana-score/README.md
@@ -2,7 +2,9 @@
 
 Self-contained composite action that:
 
-- sets up stable Dart (pub.dev-compatible scoring runtime),
+- sets up a pub.dev-compatible scoring runtime: stable Dart, or stable
+  Flutter for packages that declare `sdk: flutter` in `pubspec.yaml` (pana
+  shells out to `flutter pub` for those, and fails hard without it),
 - installs and runs `pana --json`,
 - exposes `score` and `state` outputs,
 - writes Markdown details to `$GITHUB_STEP_SUMMARY`,

--- a/.github/actions/pana-score/README.md
+++ b/.github/actions/pana-score/README.md
@@ -5,6 +5,10 @@ Self-contained composite action that:
 - sets up a pub.dev-compatible scoring runtime: stable Dart, or stable
   Flutter for packages that declare `sdk: flutter` in `pubspec.yaml` (pana
   shells out to `flutter pub` for those, and fails hard without it),
+- installs the `webp` command-line tools (`cwebp`, `dwebp`, `gif2webp`,
+  `webpmux`, `webpinfo`) pana needs to score example/README screenshots —
+  see [dart-lang/pana#1553](https://github.com/dart-lang/pana/issues/1553)
+  (Linux runners only; other runners get a warning instead),
 - installs and runs `pana --json`,
 - exposes `score` and `state` outputs,
 - writes Markdown details to `$GITHUB_STEP_SUMMARY`,

--- a/.github/actions/pana-score/action.yaml
+++ b/.github/actions/pana-score/action.yaml
@@ -76,6 +76,33 @@ runs:
         channel: stable # the score has to be the one pub.dev will give
         cache: true
 
+    # pana shells out to these WebP tools to score example/README screenshots.
+    # Without them it doesn't error clearly, it just fails that check (or the
+    # whole run) with an opaque "No such file or directory".
+    # See: https://github.com/dart-lang/pana/issues/1553
+    - name: Check for webp tools required by pana
+      id: webp-check
+      shell: bash
+      run: |
+        missing=false
+        for tool in cwebp dwebp gif2webp webpmux webpinfo; do
+          command -v "$tool" >/dev/null 2>&1 || missing=true
+        done
+        echo "missing=$missing" >> "$GITHUB_OUTPUT"
+
+    - name: Install webp tools required by pana
+      if: steps.webp-check.outputs.missing == 'true' && runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y --no-install-recommends webp
+
+    - name: Warn about missing webp tools
+      if: steps.webp-check.outputs.missing == 'true' && runner.os != 'Linux'
+      shell: bash
+      run: |
+        echo "::warning title=pana score::cwebp, dwebp, gif2webp, webpmux, and webpinfo are not on PATH, and this action only installs them automatically on Linux runners. pana's screenshot scoring may fail or produce incorrect deductions; install libwebp's command-line tools yourself (e.g. 'brew install webp' on macOS)."
+
     - name: Install pana
       shell: bash
       run: |

--- a/.github/actions/pana-score/action.yaml
+++ b/.github/actions/pana-score/action.yaml
@@ -1,7 +1,7 @@
 name: Score package with pana
 description: >
-  Set up stable Dart, run pana on a package, publish a summary, and report a
-  `pana` commit status.
+  Set up stable Dart (or Flutter, for packages that need it), run pana on a
+  package, publish a summary, and report a `pana` commit status.
 
 inputs:
   path:
@@ -26,9 +26,25 @@ runs:
   using: composite
 
   steps:
+    # Packages that depend on the Flutter SDK (`sdk: flutter` in pubspec.yaml)
+    # need `flutter` on PATH: pana shells out to `flutter pub` for them, and
+    # falls over hard (not just a lower score) if only plain Dart is present.
+    - name: Check whether the package requires Flutter
+      id: package-check
+      shell: bash
+      env:
+        PACKAGE_PATH: ${{ inputs.path }}
+      run: |
+        needs_flutter=false
+        if grep -qE '^\s*sdk:\s*flutter\s*$' "$PACKAGE_PATH/pubspec.yaml" 2>/dev/null; then
+          needs_flutter=true
+        fi
+        echo "needs-flutter=$needs_flutter" >> "$GITHUB_OUTPUT"
+
     # Avoids re-downloading (and colliding with leftover files) when Dart is already up to date.
     - name: Check for an up-to-date stable Dart SDK
       id: dart-check
+      if: steps.package-check.outputs.needs-flutter != 'true'
       shell: bash
       run: |
         latest="$(curl -fsSL https://storage.googleapis.com/dart-archive/channels/stable/release/latest/VERSION | jq -r '.version' || true)"
@@ -43,15 +59,22 @@ runs:
         echo "up-to-date=$up_to_date" >> "$GITHUB_OUTPUT"
 
     - name: Clear stale Dart SDK download
-      if: steps.dart-check.outputs.up-to-date != 'true'
+      if: steps.package-check.outputs.needs-flutter != 'true' && steps.dart-check.outputs.up-to-date != 'true'
       shell: bash
       run: rm -f "$RUNNER_TEMP"/dartsdk-*.zip
 
     - name: Set up stable Dart for pana
-      if: steps.dart-check.outputs.up-to-date != 'true'
+      if: steps.package-check.outputs.needs-flutter != 'true' && steps.dart-check.outputs.up-to-date != 'true'
       uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
       with:
         sdk: stable # the score has to be the one pub.dev will give
+
+    - name: Set up stable Flutter for pana
+      if: steps.package-check.outputs.needs-flutter == 'true'
+      uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+      with:
+        channel: stable # the score has to be the one pub.dev will give
+        cache: true
 
     - name: Install pana
       shell: bash


### PR DESCRIPTION
## Summary

- Sets up stable Flutter (instead of plain Dart) for packages that declare `sdk: flutter` in `pubspec.yaml`. pana shells out to `flutter pub` for these, and previously failed outright with only Dart on PATH.
- Installs the `webp` command-line tools (`cwebp`, `dwebp`, `gif2webp`, `webpmux`, `webpinfo`) pana needs to score example/README screenshots, on Linux runners; warns instead of failing silently on other runners. See [dart-lang/pana#1553](https://github.com/dart-lang/pana/issues/1553).

## Test plan

- [ ] Validated `action.yaml` as valid YAML.
- [ ] Verified the `webp` apt package on Ubuntu 24.04 (the runner image this targets) ships all five required binaries (`cwebp`, `dwebp`, `gif2webp`, `webpmux`, `webpinfo`) by inspecting the `.deb` contents.
- [ ] Exercise the action against a real Flutter package and a real Dart-only package in a consuming workflow to confirm both paths still produce a valid score.


---
_Generated by [Claude Code](https://claude.ai/code/session_01L9v5aBTo2mA9ikYfKe6xzy)_