### PR TITLE
Add BS_BUILD_NAME support to bs_ios and bs_android

### DIFF
--- a/bin/bs_android
+++ b/bin/bs_android
@@ -13,6 +13,7 @@ set -uo pipefail
 BS_CREDENTIALS="${BS_CREDENTIALS:-}"
 BS_PROJECT="${BS_PROJECT:-}"
 BS_ANDROID_DEVICES="${BS_ANDROID_DEVICES:-}"
+BS_BUILD_NAME="${BS_BUILD_NAME:-}"
 BS_SKIP_BUILD="${BS_SKIP_BUILD:-0}"
 BS_IDLE_TIMEOUT="${BS_IDLE_TIMEOUT:-900}"
 
@@ -111,6 +112,12 @@ echo 1>&2 "Uploaded test instrumentation app, url: $test_url"
 
 # https://www.browserstack.com/docs/app-automate/api-reference/espresso/builds#execute-a-build
 printf 1>&2 "Will schedule test execution\n\n"
+
+custom_build_name_field=""
+if [ -n "$BS_BUILD_NAME" ]; then
+	custom_build_name_field="\"customBuildName\": \"$BS_BUILD_NAME\","
+fi
+
 if ! run_response="$(
 	curl --fail-with-body --user "$BS_CREDENTIALS" \
 		--request POST "https://api-cloud.browserstack.com/app-automate/espresso/v2/build" \
@@ -120,6 +127,7 @@ if ! run_response="$(
     "app": "$app_url",
     "testSuite": "$test_url",
     "project": "$BS_PROJECT",
+    $custom_build_name_field
     "devices": $BS_ANDROID_DEVICES,
     "singleRunnerInvocation": "true",
     "useOrchestrator": "true",

--- a/bin/bs_ios
+++ b/bin/bs_ios
@@ -16,6 +16,9 @@ set -uo pipefail
 BS_CREDENTIALS="${BS_CREDENTIALS:-}"
 BS_PROJECT="${BS_PROJECT:-}"
 BS_IOS_DEVICES="${BS_IOS_DEVICES:-}"
+# BrowserStack's xcuitest v2 endpoint has no field for a custom build name, so this is used to set the ipa filename
+# instead. BrowserStack builds the build name based on the ipa name + app version: e.g. `BS_BUILD_NAME.ipa v1.0.0"
+BS_BUILD_NAME="${BS_BUILD_NAME:-}"
 BS_SKIP_BUILD="${BS_SKIP_BUILD:-0}"
 BS_IDLE_TIMEOUT="${BS_IDLE_TIMEOUT:-900}"
 
@@ -81,7 +84,10 @@ cd build/ios_integ/Build/Products || exit 1
 
 rm -rf Payload && mkdir -p Payload
 cp -r "Release${FLAVOR_SUFFIXED}iphoneos/Runner.app" Payload
-zip -r Runner.ipa Payload >/dev/null
+
+# The ipa filename doubles as the "build name" shown by BrowserStack, see BS_BUILD_NAME above.
+ipa_filename="${BS_BUILD_NAME:-Runner}.ipa"
+zip -r "$ipa_filename" Payload >/dev/null
 
 cd - >/dev/null || exit 1
 
@@ -97,7 +103,7 @@ cd - >/dev/null || exit 1
 
 echo 1>&2 "Created zip archive"
 
-app_path="$PWD/build/ios_integ/Build/Products/Runner.ipa"
+app_path="$PWD/build/ios_integ/Build/Products/$ipa_filename"
 if [ ! -f "$app_path" ]; then
 	echo 1>&2 "Error: app under test not found at $app_path"
 	exit 1


### PR DESCRIPTION
Allows setting a custom BrowserStack build name via the BS_BUILD_NAME env var, consistent across both scripts:
- bs_android passes it as customBuildName in the espresso build request.
- bs_ios uses it as the ipa filename, since BrowserStack's xcuitest v2 endpoint has no custom build name field and instead displays the ipa filename as the build name.